### PR TITLE
Ignore uncheckable schemes

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,10 +9,10 @@
 Install only packages you need. See `packages/*` folder.
 
 Here are the list of rules:
-1. `remark-are-links-valid-duplicate` - checks that link is unique on a page
-2. `remark-are-links-valid-alive` - checks that link is reachable
+1. `remark-lint-are-links-valid-duplicate` - checks that link is unique on a page
+2. `remark-lint-are-links-valid-alive` - checks that link is reachable
 
 
 ## License
 
-MIT, see [LICENSE.md](LICENCE.md) for details.
+MIT, see [LICENSE.md](LICENSE.md) for details.

--- a/packages/alive/src.js
+++ b/packages/alive/src.js
@@ -8,8 +8,23 @@ function handleLinkDuplicateError (file, link, reason) {
   file.info(message, node)
 }
 
+function findCheckableLinks (ast) {
+  const ignoredSchemes = [
+    'data:',
+    'geo:',
+    'irc:',
+    'mailto:',
+    'sms:',
+    'tel:'
+  ]
+
+  return main.findLinks(ast).filter(link => {
+    return ignoredSchemes.indexOf(link.link.protocol) === -1
+  })
+}
+
 function areLinksAlive (ast, file, options, done) {
-  const links = main.findLinks(ast)
+  const links = findCheckableLinks(ast)
   const settings = main.getSettings(options)
 
   const urlChecker = new blc.UrlChecker(settings, {

--- a/test/test_alive.js
+++ b/test/test_alive.js
@@ -59,4 +59,28 @@ describe('Are links alive', () => {
         .notify(done)
     })
   })
+
+  describe('Ignored schemes', () => {
+    const ignoredURLs = [
+      {scheme: 'data', link: 'data:image/gif;base64,R0lGODlhAQABAAD/ACwAAAAAAQABAAACADs='},
+      {scheme: 'geo', link: 'geo:37.786971,-122.399677'},
+      {scheme: 'irc', link: 'irc://irc.freenode.net/elixir-lang'},
+      {scheme: 'mailto', link: 'mailto:contact@wemake.services'},
+      {scheme: 'sms', link: 'sms:?body=Hello'},
+      {scheme: 'tel', link: 'tel:1-408-555-5555'}
+    ]
+
+    ignoredURLs.forEach(({scheme, link}) => {
+      it(`Expect no warnings on ${scheme} scheme`, (done) => {
+        const result = lint(`
+          # I sure do love links
+          [${scheme} link](${link})
+        `)
+
+        expect(result).to.eventually.have
+          .property('messages').lengthOf(0)
+          .notify(done)
+      })
+    })
+  })
 })


### PR DESCRIPTION
Fixes #7 

`broken-link-checker` can be configured to ignore certain schemes on all its 
classes except `UrlChecker` which is was `remark-lint-are-links-valid-alive` uses. 
Instead we'll filter the urls before calling `UrlChecker` and ignore certain schemes entirely.

Ignored schemes: `data:`, `geo:`, `irc:`, `mailto:`, `sms:`, `tel:`

There are many more and this could certainly be a config option for the plugin. 
Didn't go further since it would mean splitting the API (our options and `UrlChecker` options).